### PR TITLE
minor: adjust default timer field to something generic

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: test suite
 
 on:
-  pull_request:
+  pull_request_target:
   push:
     branches:
       - master

--- a/composer.json
+++ b/composer.json
@@ -39,11 +39,14 @@
         "phpunit/phpunit": "^10.4.2",
         "symfony/browser-kit": "^6.3.2|^7.0",
         "symfony/css-selector": "^6.3.2|^7.0",
-        "symfony/debug-pack": "^1.0.10",
+        "symfony/debug-bundle": "^6.3|^7.0",
         "symfony/dotenv": "^6.3.7|^7.0",
+        "symfony/monolog-bundle": "^3.0",
         "symfony/routing": "^6.3.5|^7.0",
         "symfony/runtime": "^6.3.2|^7.0",
-        "symfony/twig-bundle": "^6.3|^7.0"
+        "symfony/stopwatch": "^6.3|^7.0",
+        "symfony/twig-bundle": "^6.3|^7.0",
+        "symfony/web-profiler-bundle": "^6.3|^7.0"
     },
     "autoload": {
         "psr-4": { "Omines\\AntiSpamBundle\\": "src/"}

--- a/docs/mkdocs/configuration.md
+++ b/docs/mkdocs/configuration.md
@@ -61,7 +61,7 @@ antispam:
          timer:
 
             # Base name of the injected field
-            field:                __antispam_time
+            field:                ___token
             min:                  3
             max:                  3600
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -164,7 +164,7 @@ class Configuration implements ConfigurationInterface
                 ->children()
                     ->scalarNode('field')
                         ->info('Base name of the injected field')
-                        ->defaultValue('__antispam_time')
+                        ->defaultValue('___token')
                     ->end()
                     ->integerNode('min')->defaultValue(SubmitTimerType::DEFAULT_MIN)->min(0)->end()
                     ->integerNode('max')->defaultValue(SubmitTimerType::DEFAULT_MAX)->min(60)->end()

--- a/tests/Unit/Fixtures/config-1-output.yaml
+++ b/tests/Unit/Fixtures/config-1-output.yaml
@@ -23,7 +23,7 @@ profiles:
     timer:
       min: 3
       max: 3600
-      field: __antispam_time
+      field: ___token
 
     url_count:
       max: 3
@@ -36,7 +36,7 @@ profiles:
     timer:
       min: 2
       max: 3600
-      field: __antispam_time
+      field: ___token
 
     stealth: true
     passive: false


### PR DESCRIPTION
I was thinking the current name `__antispam_time` makes it a bit obvious what it's used for. What about making it more generic?