### PR TITLE
Fixing French translation errors.

### DIFF
--- a/translations/antispam+intl-icu.fr.yaml
+++ b/translations/antispam+intl-icu.fr.yaml
@@ -2,12 +2,12 @@ form:
   stealthed: 'Le formulaire soumis n'a pas pu être traité. Veuillez nous contacter si le problème persiste.'
 
   honeypot:
-    not_empty: 'Le champ de pot de miel devait être vide mais ne l'est pas.'
+    not_empty: 'Le champ du honeypot était censé être vide mais ne l'est pas.'
   timer:
     corrupted: 'Des raisons techniques ont empêché le traitement du formulaire.'
     mismatch_ip: 'Votre adresse IP a changé pendant la soumission du formulaire. Veuillez réessayer.'
-    too_fast: 'Le formulaire a été soumis de manière déraisonnablement rapide. Veuillez patienter un peu avant de réessayer.'
-    too_slow: 'Le formulaire a été soumis de manière déraisonnablement lente. Veuillez recharger la page et réessayer.'
+    too_fast: 'Le formulaire a été soumis trop rapidement. Veuillez patienter un peu avant de réessayer.'
+    too_slow: 'Le formulaire a été soumis trop lentement. Veuillez recharger la page et réessayer.'
 
 validator:
   stealthed: 'La valeur soumise n'a pas pu être traitée. Veuillez nous contacter si le problème persiste.'
@@ -20,9 +20,9 @@ validator:
     phrase_found: 'La valeur contient la phrase non autorisée "{phrase}".'
 
   banned_scripts:
-    not_allowed: 'La valeur contient des caractères de scripts non autorisés ({scripts}).'
-    percentage_exceeded: 'La valeur contient {percentage}% de caractères de scripts non autorisés ({scripts}), alors que seuls {max}% sont autorisés.'
-    characters_exceeded: 'La valeur contient {count} caractères de scripts non autorisés ({scripts}), alors que seuls {max} sont autorisés.'
+    not_allowed: 'La valeur contient des caractères provenant d'écritures non autorisées ({scripts}).'
+    percentage_exceeded: 'La valeur est composée à {percentage}% de caractères provenant d' écritures non autorisées ({scripts}). Le maximum autorisé est de : {max}%.'
+    characters_exceeded: 'La valeur contient {count} caractères provenant d' écritures non autorisées ({scripts}). Le maximum autorisé est de : {max} caractère(s).'
 
   url_count:
     exceeded: >-
@@ -30,4 +30,4 @@ validator:
         =1    {La valeur contient une URL. Ceci n'est pas autorisé.}
         other {La valeur contient # URLs. Il devrait y en avoir au maximum {limit}.}
       }
-    duplicates: 'La valeur contient l'URL {url} {count} fois, ce qui dépasse la limite autorisée de {limit}.'
+    duplicates: 'La valeur contient l'URL {url} {count} fois. La limite maximum est de : {limit} fois.'


### PR DESCRIPTION
Improved initial french translation:
Changed "caractères de script" to "caractères d'écritures" as it was incorrect.
Added other minors changes to make it look a little more native.