### PR TITLE
Dropping hard-coded `style="display:none"` in favor of custom `class`

### DIFF
--- a/src/Form/Type/HoneypotType.php
+++ b/src/Form/Type/HoneypotType.php
@@ -31,15 +31,6 @@ class HoneypotType extends NonInteractiveAntiSpamType
         });
     }
 
-    public function configureOptions(OptionsResolver $resolver): void
-    {
-        parent::configureOptions($resolver);
-
-        $resolver->setDefault('attr', [
-            'style' => 'display:none',
-        ]);
-    }
-
     public function getParent(): ?string
     {
         return FormType::class;


### PR DESCRIPTION
Right now, the `HoneypotType` has `style="display:none"` hard-coded. Don't you think that this is really easy to detect for spambots?

So my idea would be to use a CSS `class` for that, with a name chosen by the user. So I'd add something like this to the recipe:

```yaml
attributes:
    class: 'noShow' # change this to some other name to make it harder to detect for spambots
```

What do you think?